### PR TITLE
Added method to create a Piece.Requirement array

### DIFF
--- a/ValheimLib/ODB/CustomRecipe.cs
+++ b/ValheimLib/ODB/CustomRecipe.cs
@@ -1,5 +1,6 @@
 ﻿using UnityEngine;
 using UnityObject = UnityEngine.Object;
+using System.Collections.Generic;
 
 namespace ValheimLib.ODB
 {
@@ -30,6 +31,20 @@ namespace ValheimLib.ODB
             requirement.m_resItem = Mock<ItemDrop>.Create(name);
 
             return requirement;
+        }
+
+        public static Piece.Requirement[] CreateArray(Dictionary<string, int> requirements, bool recover = true)
+        {
+            List<Piece.Requirement> list = new List<Piece.Requirement>();
+
+            foreach (KeyValuePair<string, int> requirement in requirements)
+            {
+                Piece.Requirement piece = Create(requirement.Key, requirement.Value, recover);
+                piece.FixReferences();
+                list.Add(piece);
+            }
+
+            return list.ToArray();
         }
     }
 }


### PR DESCRIPTION
I made this to quicker assign a piece.m_resources array. 

It looks like this:
```
piece.m_resources = MockRequirement.CreateArray(new Dictionary<string, int> {
    {"Wood", 3},
    {"SurtlingCore", 1}
});
```