### PR TITLE
reload known recipies at start

### DIFF
--- a/ValheimLib/ODB/ObjectDBHelper.cs
+++ b/ValheimLib/ODB/ObjectDBHelper.cs
@@ -20,6 +20,7 @@ namespace ValheimLib.ODB
         {
             On.ObjectDB.Awake += AddCustomData;
             On.ZNetScene.Awake += AddCustomPrefabsToZNetSceneDictionary;
+            On.Player.Load += ReloadKnownRecipes;
 
             SaveCustomData.Init();
 
@@ -145,6 +146,18 @@ namespace ValheimLib.ODB
             {
                 self.m_namedPrefabs.Add(customItem.ItemPrefab.name.GetStableHashCode(), customItem.ItemPrefab);
             }
+        }
+
+        private static void ReloadKnownRecipes(On.Player.orig_Load orig, Player self, ZPackage pkg) 
+        {
+            orig(self, pkg);
+
+            if (Game.instance == null) 
+            {
+                return;
+            }
+
+            self.UpdateKnownRecipesList();
         }
     }
 


### PR DESCRIPTION
This fixes a bug in Valheim, were new recipes are not added when the player spawns. It is added when the inventory updates (eg. by picking an item up)

It's because the player calls UpdateKnownRecipesList() in Awake(), but Load() hasn't be called, so m_knownMaterial has no elements. Therefore no new recipies can be added.